### PR TITLE
Overwrite cache to allow re-opening of existing images

### DIFF
--- a/galasa-eclipse-parent/dev.galasa.eclipse/src/dev/galasa/eclipse/ui/run/storedartifacts/LoadImageJob.java
+++ b/galasa-eclipse-parent/dev.galasa.eclipse/src/dev/galasa/eclipse/ui/run/storedartifacts/LoadImageJob.java
@@ -1,8 +1,12 @@
+/*
+ * Copyright contributors to the Galasa project
+ */
 package dev.galasa.eclipse.ui.run.storedartifacts;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
@@ -27,7 +31,7 @@ public class LoadImageJob extends Job {
 		try {
 			String fileName = this.imagePath.getFileName().toString();
 			Path cachePath = Activator.getCachePath().resolve(fileName);
-			Files.copy(this.imagePath, cachePath);
+			Files.copy(this.imagePath, cachePath, StandardCopyOption.REPLACE_EXISTING);
 			
 			view.setCachedImagePath(cachePath);
 			view.loadImagetoUI();


### PR DESCRIPTION
Discovered as part of https://github.com/galasa-dev/projectmanagement/issues/1381

Resolves an issue where re-opening an image or opening an image with the same file name as a previously-opened image results in a file copy error.