### PR TITLE
Use new m2e-core APIs to support Eclipse 2022-09 and above

### DIFF
--- a/galasa-eclipse-parent/dev.galasa.eclipse.feature/pom.xml
+++ b/galasa-eclipse-parent/dev.galasa.eclipse.feature/pom.xml
@@ -62,7 +62,7 @@
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
-			<version>2.7</version>
+			<version>2.9.1</version>
 		</dependency>
 	</dependencies>
 

--- a/galasa-eclipse-parent/dev.galasa.eclipse.site/pom.xml
+++ b/galasa-eclipse-parent/dev.galasa.eclipse.site/pom.xml
@@ -22,7 +22,7 @@
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<maven.build.timestamp.format>yyyyMMddHHmm</maven.build.timestamp.format>
-		<tycho-version>1.4.0</tycho-version>
+		<tycho-version>3.0.4</tycho-version>
 	</properties>
 
 	<dependencies>

--- a/galasa-eclipse-parent/dev.galasa.eclipse/META-INF/MANIFEST.MF
+++ b/galasa-eclipse-parent/dev.galasa.eclipse/META-INF/MANIFEST.MF
@@ -30,6 +30,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.m2e.core
 Import-Package: javax.servlet,
  javax.servlet.http,
+ javax.inject,
  org.eclipse.core.resources,
  org.eclipse.jetty.server;version="9.4.0",
  org.eclipse.jetty.server.handler;version="9.4.0",

--- a/galasa-eclipse-parent/dev.galasa.eclipse/pom.xml
+++ b/galasa-eclipse-parent/dev.galasa.eclipse/pom.xml
@@ -36,7 +36,7 @@
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
-			<version>2.7</version>
+			<version>2.9.1</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-logging</groupId>

--- a/galasa-eclipse-parent/dev.galasa.eclipse/src/dev/galasa/eclipse/launcher/Launcher.java
+++ b/galasa-eclipse-parent/dev.galasa.eclipse/src/dev/galasa/eclipse/launcher/Launcher.java
@@ -351,13 +351,13 @@ public class Launcher extends JavaLaunchDelegate {
                     }
                 } else if (workspaceProject.hasNature(MAVEN_NATURE)) {
                     IMavenProjectFacade mavenProjectFacade = MavenPlugin.getMavenProjectRegistry().getProject(workspaceProject);
-                    String version = mavenProjectFacade.getArtifactKey().getVersion();
+                    String version = mavenProjectFacade.getArtifactKey().version();
 
                     IPath outputPath = mavenProjectFacade.getOutputLocation().removeLastSegments(1);
                     IResource actualOutputPath = workspaceRoot.findMember(outputPath);
                     java.nio.file.Path realOutputPath = Paths.get(actualOutputPath.getLocationURI());
                     
-                    String artifactId = mavenProjectFacade.getArtifactKey().getArtifactId();
+                    String artifactId = mavenProjectFacade.getArtifactKey().artifactId();
                     if (artifactId == null) {
                         rejectedBundles.put(workspaceProject.getName(), "Artifact ID is missing from project");
                         continue;
@@ -458,13 +458,13 @@ public class Launcher extends JavaLaunchDelegate {
 			if (actualProject.hasNature(MAVEN_NATURE)) {
 				consoleDefault.append("This is a maven project: " + project + "\n");
 				IMavenProjectFacade mavenProjectFacade = MavenPlugin.getMavenProjectRegistry().getProject(actualProject);
-				String version = mavenProjectFacade.getArtifactKey().getVersion();
+				String version = mavenProjectFacade.getArtifactKey().version();
 				
 				IPath outputPath = mavenProjectFacade.getOutputLocation().removeLastSegments(1);
 				IResource actualOutputPath = workspaceRoot.findMember(outputPath);
 				java.nio.file.Path realOutputPath = Paths.get(actualOutputPath.getRawLocationURI());
 				
-				String artifactId = mavenProjectFacade.getArtifactKey().getArtifactId();
+				String artifactId = mavenProjectFacade.getArtifactKey().artifactId();
 				if (artifactId == null) {
 				    consoleDefault.append("Artifact ID is missing from project: " + project + "\n");
 				    return null;

--- a/galasa-eclipse-parent/dev.galasa.eclipse/src/dev/galasa/eclipse/launcher/Launcher.java
+++ b/galasa-eclipse-parent/dev.galasa.eclipse/src/dev/galasa/eclipse/launcher/Launcher.java
@@ -1,7 +1,5 @@
 /*
- * Licensed Materials - Property of IBM
- * 
- * (c) Copyright IBM Corp. 2019,2021.
+ * Copyright contributors to the Galasa project 
  */
 package dev.galasa.eclipse.launcher;
 

--- a/galasa-eclipse-parent/dev.galasa.simbank.ui/src/dev/galasa/eclipse/ui/wizards/simbank/ExampleMavenSimbankOperation.java
+++ b/galasa-eclipse-parent/dev.galasa.simbank.ui/src/dev/galasa/eclipse/ui/wizards/simbank/ExampleMavenSimbankOperation.java
@@ -1,7 +1,5 @@
 /*
- * Licensed Materials - Property of IBM
- * 
- * (c) Copyright IBM Corp. 2019,2021.
+ * Copyright contributors to the Galasa project 
  */
 package dev.galasa.eclipse.ui.wizards.simbank;
 
@@ -147,13 +145,7 @@ public class ExampleMavenSimbankOperation implements IRunnableWithProgress {
             managerProject.setDescription(managerDescription, monitor);
 
             @SuppressWarnings("restriction")
-            UpdateMavenProjectJob job = new UpdateMavenProjectJob(Arrays.asList(new IProject[] { testProject, managerProject }));// TODO
-                                                                                                                  // find
-                                                                                                                  // official
-                                                                                                                  // way
-                                                                                                                  // to
-                                                                                                                  // do
-                                                                                                                  // this
+            UpdateMavenProjectJob job = new UpdateMavenProjectJob(Arrays.asList(new IProject[] { testProject, managerProject }));
             job.schedule();
 
         } catch (Throwable t) {

--- a/galasa-eclipse-parent/dev.galasa.simbank.ui/src/dev/galasa/eclipse/ui/wizards/simbank/ExampleMavenSimbankOperation.java
+++ b/galasa-eclipse-parent/dev.galasa.simbank.ui/src/dev/galasa/eclipse/ui/wizards/simbank/ExampleMavenSimbankOperation.java
@@ -147,7 +147,7 @@ public class ExampleMavenSimbankOperation implements IRunnableWithProgress {
             managerProject.setDescription(managerDescription, monitor);
 
             @SuppressWarnings("restriction")
-            UpdateMavenProjectJob job = new UpdateMavenProjectJob(new IProject[] { testProject, managerProject });// TODO
+            UpdateMavenProjectJob job = new UpdateMavenProjectJob(Arrays.asList(new IProject[] { testProject, managerProject }));// TODO
                                                                                                                   // find
                                                                                                                   // official
                                                                                                                   // way

--- a/galasa-eclipse-parent/pom.xml
+++ b/galasa-eclipse-parent/pom.xml
@@ -73,8 +73,8 @@
 	<properties>
 	    <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.source>11</maven.compiler.source>
-		<tycho-version>1.4.0</tycho-version>
-		<tycho-extras.version>1.4.0</tycho-extras.version>
+		<tycho-version>3.0.4</tycho-version>
+		<tycho-extras.version>3.0.4</tycho-extras.version>
 		<tycho.disableP2Mirrors>true</tycho.disableP2Mirrors>
 		<!-- Exclude tests until Jenkins display issue resolved -->
 		<skipTests>true</skipTests>

--- a/galasa-eclipse-parent/pom.xml
+++ b/galasa-eclipse-parent/pom.xml
@@ -150,7 +150,7 @@
 				<version>${tycho-version}</version>
 				<dependencies>
 					<dependency>
-						<groupId>org.eclipse.tycho.extras</groupId>
+						<groupId>org.eclipse.tycho</groupId>
 						<artifactId>tycho-buildtimestamp-jgit</artifactId>
 						<version>${tycho-extras.version}</version>
 					</dependency>


### PR DESCRIPTION
For https://github.com/galasa-dev/projectmanagement/issues/1201

- [x] Switch to using the new m2e-core APIs as a result of:
  - https://github.com/eclipse-m2e/m2e-core/commit/c3ade997e33c06d9a5863aa4985446bdb71e49a2#diff-793802133e7afec3fa214b7866fc321fa7d6c69eacff4033094c6fe234a1111eL149-L151
  - https://github.com/eclipse-m2e/m2e-core/commit/8b876a6748d8858578ee5894c40a872affc0e052#diff-c669a49fb01fb54160fb690a6183e53b8cab8a370783bfdf94e333d524cdc078L51-R52
- [x] Build the Eclipse plugin with Java 17, ensuring Java 11 is targetted during compilation
  - [x] Bump Tycho to 3.0.4, as 1.4.0 does not support Java 17 and fix any build failures as a result of this
- [x] Run tests using the new plugin installed on Eclipse 2022-09 and 2023-03

To try the new version of the plugin yourself, install it on Eclipse from: Help > Install New Software, entering https://development.galasa.dev/iss1201/maven-repo/p2 as the site to install from.