### PR TITLE
Iss1538 - Changing optional provider-name tag to Galasa

### DIFF
--- a/galasa-eclipse-parent/dev.galasa.eclipse.feature/feature.xml
+++ b/galasa-eclipse-parent/dev.galasa.eclipse.feature/feature.xml
@@ -3,7 +3,7 @@
       id="dev.galasa.eclipse.feature"
       label="Galasa Core"
       version="0.31.0.qualifier"
-      provider-name="IBM">
+      provider-name="Galasa">
 
    <copyright>
       Copyright contributors to the Galasa project

--- a/galasa-eclipse-parent/dev.galasa.simbank.feature/feature.xml
+++ b/galasa-eclipse-parent/dev.galasa.simbank.feature/feature.xml
@@ -3,7 +3,7 @@
       id="dev.galasa.simbank.feature"
       version="0.31.0.qualifier"
       label="Galasa SimBank"
-      provider-name="IBM">
+      provider-name="Galasa">
 
    <copyright>
       Copyright contributors to the Galasa project


### PR DESCRIPTION
For https://github.com/galasa-dev/projectmanagement/issues/1538 - IBM related files should not live in github.com.

According to the Eclipse docs here https://help.eclipse.org/latest/index.jsp?topic=%2Forg.eclipse.pde.doc.user%2Fguide%2Ftools%2Feditors%2Ffeature_editor%2Finformation.htm the provider-name tag is optional anyway so could have just been removed, but is simply a 'display label identifying the organization providing this component.'. I believe replacing IBM with Galasa makes sense here. 